### PR TITLE
(#17) Fix return type of findManyRandom with no second argument

### DIFF
--- a/example/db.test.ts
+++ b/example/db.test.ts
@@ -29,15 +29,26 @@ const STD_RATIO = 3.4641016151377544;
 
 beforeEach(async () => {
   await prisma.user.deleteMany();
+  await prisma.post.deleteMany();
+  await prisma.strange.deleteMany();
+
   for (let i = 1; i <= POPULATION; ++i) {
-    await prisma.user.create({
+    const user = await prisma.user.create({
       data: {
         firstName: 'User' + (i % 2),
         lastName: i.toString(),
       },
     });
+    for (let i = 1; i <= 1; ++i) {
+      await prisma.post.create({
+        data: {
+          author: { connect: { id: user.id } },
+          title: 'Title',
+        },
+      });
+    }
   }
-  for (let i = 1; i <= 1000; ++i) {
+  for (let i = 1; i <= 10; ++i) {
     await prisma.strange.create({
       data: { value: 'value ' + i },
     });
@@ -46,6 +57,8 @@ beforeEach(async () => {
 
 test('empty findRandom', async () => {
   await prisma.user.deleteMany();
+  await prisma.post.deleteMany();
+  await prisma.strange.deleteMany();
 
   const user = await prisma.user.findRandom();
   const post = await prisma.post.findRandom();
@@ -57,10 +70,13 @@ test('empty findRandom', async () => {
 
   assert.isNull(user);
   assert.isNull(post);
+  assert.isNull(strange);
 });
 
 test('empty findManyRandom', async () => {
   await prisma.user.deleteMany();
+  await prisma.post.deleteMany();
+  await prisma.strange.deleteMany();
 
   const users = await prisma.user.findManyRandom(10000);
   const posts = await prisma.post.findManyRandom(10000);

--- a/example/db.test.ts
+++ b/example/db.test.ts
@@ -1,5 +1,26 @@
 import { prisma } from './db.js';
-import { assert, beforeEach, test } from 'vitest';
+import { assert, beforeEach, expect, expectTypeOf, test } from 'vitest';
+
+interface User {
+  id: number;
+  firstName: string;
+  lastName: string;
+}
+
+interface Post {
+  id: number;
+  title: string;
+  content: string | null;
+  published: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  authorId: number;
+}
+
+interface Strange {
+  key: number;
+  value: string;
+}
 
 const POPULATION = 1000;
 const NUM_TRIALS = 10000;
@@ -20,14 +41,47 @@ beforeEach(async () => {
 
 test('empty findRandom', async () => {
   await prisma.user.deleteMany();
+
   const user = await prisma.user.findRandom();
+  const post = await prisma.post.findRandom();
+  const strange = await prisma.strange.findRandom();
+
+  expectTypeOf(user).toMatchTypeOf<User | null>();
+  expectTypeOf(post).toMatchTypeOf<Post | null>();
+  expectTypeOf(strange).toMatchTypeOf<Strange | null>();
+
   assert.isNull(user);
+  assert.isNull(post);
 });
 
 test('empty findManyRandom', async () => {
   await prisma.user.deleteMany();
+
   const users = await prisma.user.findManyRandom(10000);
+  const posts = await prisma.post.findManyRandom(10000);
+
+  expectTypeOf(users).toMatchTypeOf<{ id: number }[]>();
+  expectTypeOf(posts).toMatchTypeOf<{ id: number }[]>();
+
   assert.isEmpty(users);
+  assert.isEmpty(posts);
+
+  // 'strange' table doesn't have an `id` column, so this should fail
+  expect(
+    async () => await prisma.strange.findManyRandom(10000),
+  ).rejects.toThrowError();
+});
+
+test('custom unique key', async () => {
+  const strange = await prisma.strange.findManyRandom(5, {
+    custom_uniqueKey: 'key',
+  });
+
+  expectTypeOf(strange).toMatchTypeOf<{ key: number }[]>();
+  assert(strange.length === 5);
+  assert(
+    strange[0] && 'key' in strange[0] && typeof strange[0].key === 'number',
+  );
 });
 
 test('findRandom distribution', async () => {

--- a/example/db.test.ts
+++ b/example/db.test.ts
@@ -37,6 +37,11 @@ beforeEach(async () => {
       },
     });
   }
+  for (let i = 1; i <= 1000; ++i) {
+    await prisma.strange.create({
+      data: { value: 'value ' + i },
+    });
+  }
 });
 
 test('empty findRandom', async () => {

--- a/example/index.ts
+++ b/example/index.ts
@@ -6,7 +6,7 @@ const main = async () => {
     select: { id: true, firstName: true },
   });
 
-  const post = await prisma.post.findManyRandom(10, {
+  const posts = await prisma.post.findManyRandom(10, {
     select: { title: true },
     where: {
       OR: [
@@ -18,7 +18,16 @@ const main = async () => {
     custom_uniqueKey: 'id',
   });
 
-  console.log({ user, post });
+  const posts2 = await prisma.post.findManyRandom(10);
+
+  console.log({ user, posts, posts2 });
+
+  try {
+    const strange = await prisma.strange.findManyRandom(5);
+    console.log(strange);
+  } catch (e) {
+    console.log('there was an error');
+  }
 };
 
 main();

--- a/example/seed.ts
+++ b/example/seed.ts
@@ -89,6 +89,12 @@ const main = async () => {
       });
     }
   }
+
+  for (let i = 1; i <= 1000; ++i) {
+    await prisma.strange.create({
+      data: { value: 'value ' + i },
+    });
+  }
 };
 
 main();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,3 +30,8 @@ model Post {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 }
+
+model Strange {
+  key   Int    @id @default(autoincrement())
+  value String
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export default (_extensionArgs?: Args) =>
           )) as Prisma.Result<T, A, 'findFirst'>;
         },
 
-        async findManyRandom<T, TWhere, TSelect, TUnique extends string>(
+        async findManyRandom<T, TWhere, TSelect, TUnique extends string = 'id'>(
           this: T,
           num: number,
           args?: {


### PR DESCRIPTION
Fixes https://github.com/nkeil/prisma-extension-random/issues/17

* When there is no second argument to `findManyRandom`, the return type should reflect the default `uniqueKey` of `id`
* Adds additional test coverage to ensure proper return types